### PR TITLE
fix: namespace ObjC code to avoid clash

### DIFF
--- a/sparkle.go
+++ b/sparkle.go
@@ -13,40 +13,40 @@ package sparkle
 
 #include <stdlib.h>
 
-void initialize();
+void sparkle_initialize();
 
-void checkForUpdates();
+void sparkle_checkForUpdates();
 
-void checkForUpdatesInBackground();
+void sparkle_checkForUpdatesInBackground();
 
-void setAutomaticallyChecksForUpdates(int);
-int automaticallyChecksForUpdates();
+void sparkle_setAutomaticallyChecksForUpdates(int);
+int sparkle_automaticallyChecksForUpdates();
 
-void setAutomaticallyDownloadsUpdates(int);
-int automaticallyDownloadsUpdates();
+void sparkle_setAutomaticallyDownloadsUpdates(int);
+int sparkle_automaticallyDownloadsUpdates();
 
-void setUpdateCheckInterval(int);
-double updateCheckInterval();
+void sparkle_setUpdateCheckInterval(int);
+double sparkle_updateCheckInterval();
 
-void checkForUpdateInformation();
+void sparkle_checkForUpdateInformation();
 
-void setFeedURL(const char*);
-const char* feedURL();
+void sparkle_setFeedURL(const char*);
+const char* sparkle_feedURL();
 
-void setUserAgentString(const char*);
-const char* userAgentString();
+void sparkle_setUserAgentString(const char*);
+const char* sparkle_userAgentString();
 
-void setSendsSystemProfile(int);
-int sendsSystemProfile();
+void sparkle_setSendsSystemProfile(int);
+int sparkle_sendsSystemProfile();
 
-void setDecryptionPassword(const char*);
-const char* decryptionPassword();
+void sparkle_setDecryptionPassword(const char*);
+const char* sparkle_decryptionPassword();
 
-double lastUpdateCheckDate();
+double sparkle_lastUpdateCheckDate();
 
-void resetUpdateCycle();
+void sparkle_resetUpdateCycle();
 
-int updateInProgress();
+int sparkle_updateInProgress();
 
 */
 import "C"
@@ -62,7 +62,7 @@ import (
 
 func init() {
 	runtime.LockOSThread()
-	C.initialize()
+	C.sparkle_initialize()
 }
 
 // Explicitly checks for updates and displays a progress dialog while doing so.
@@ -74,7 +74,7 @@ func init() {
 //
 // This will find updates that the user has opted into skipping.
 func CheckForUpdates() {
-	C.checkForUpdates()
+	C.sparkle_checkForUpdates()
 }
 
 // Checks for updates, but does not display any UI unless an update is found.
@@ -89,12 +89,12 @@ func CheckForUpdates() {
 //
 // This will not find updates that the user has opted into skipping.
 func CheckForUpdatesInBackground() {
-	C.checkForUpdatesInBackground()
+	C.sparkle_checkForUpdatesInBackground()
 }
 
 // Sets whether or not to check for updates automatically.
 func SetAutomaticallyChecksForUpdates(check bool) {
-	C.setAutomaticallyChecksForUpdates(bool2int(check))
+	C.sparkle_setAutomaticallyChecksForUpdates(bool2int(check))
 }
 
 // Returns whether or not to check for updates automatically.
@@ -103,7 +103,7 @@ func SetAutomaticallyChecksForUpdates(check bool) {
 // The update schedule cycle will be reset in a short delay after the property's new value is set.
 // This is to allow reverting this property without kicking off a schedule change immediately
 func AutomaticallyChecksForUpdates() bool {
-	return C.automaticallyChecksForUpdates() != 0
+	return C.sparkle_automaticallyChecksForUpdates() != 0
 }
 
 // Sets whether or not updates can be automatically downloaded in the background.
@@ -114,7 +114,7 @@ func AutomaticallyChecksForUpdates() bool {
 //
 // Setting this property will persist in the host bundle's user defaults.
 func SetAutomaticallyDownloadsUpdates(check bool) {
-	C.setAutomaticallyDownloadsUpdates(bool2int(check))
+	C.sparkle_setAutomaticallyDownloadsUpdates(bool2int(check))
 }
 
 // Returns whether or not updates can be automatically downloaded in the background.
@@ -123,7 +123,7 @@ func SetAutomaticallyDownloadsUpdates(check bool) {
 // or by the user's system if silent updates cannot be done (eg: if they require authentication).
 // In this case, -automaticallyDownloadsUpdates will return NO regardless of how this property is set.
 func AutomaticallyDownloadsUpdates() bool {
-	return C.automaticallyDownloadsUpdates() != 0
+	return C.sparkle_automaticallyDownloadsUpdates() != 0
 }
 
 // Sets the automatic update check interval.
@@ -132,12 +132,12 @@ func AutomaticallyDownloadsUpdates() bool {
 // The update schedule cycle will be reset in a short delay after the property's new value is set.
 // This is to allow reverting this property without kicking off a schedule change immediately
 func SetUpdateCheckInterval(duration time.Duration) {
-	C.setUpdateCheckInterval(C.int(duration.Seconds()))
+	C.sparkle_setUpdateCheckInterval(C.int(duration.Seconds()))
 }
 
 // Returns the current automatic update check interval.
 func UpdateCheckInterval() time.Duration {
-	return time.Duration(C.updateCheckInterval()) * time.Second
+	return time.Duration(C.sparkle_updateCheckInterval()) * time.Second
 }
 
 // Begins a "probing" check for updates which will not actually offer to
@@ -150,7 +150,7 @@ func UpdateCheckInterval() time.Duration {
 //
 // Updates that have been skipped by the user will not be found.
 func CheckForUpdateInformation() {
-	C.checkForUpdateInformation()
+	C.sparkle_checkForUpdateInformation()
 }
 
 // Sets the URL of the appcast used to download update information.
@@ -163,53 +163,53 @@ func CheckForUpdateInformation() {
 func SetFeedURL(url string) {
 	u := C.CString(url)
 	defer C.free(unsafe.Pointer(u))
-	C.setFeedURL(u)
+	C.sparkle_setFeedURL(u)
 }
 
 // Returns the URL of the appcast used to download update information.
 func FeedURL() string {
-	return C.GoString(C.feedURL())
+	return C.GoString(C.sparkle_feedURL())
 }
 
 // Sets the user agent used when checking for updates.
 func SetUserAgentString(ua string) {
 	u := C.CString(ua)
 	defer C.free(unsafe.Pointer(u))
-	C.setUserAgentString(u)
+	C.sparkle_setUserAgentString(u)
 }
 
 // Returns the user agent used when checking for updates.
 func UserAgentString() string {
-	return C.GoString(C.userAgentString())
+	return C.GoString(C.sparkle_userAgentString())
 }
 
 // Sets whether or not the user's system profile information is sent when checking for updates.
 //
 // Setting this property will persist in the host bundle's user defaults.
 func SetSendsSystemProfile(check bool) {
-	C.setSendsSystemProfile(bool2int(check))
+	C.sparkle_setSendsSystemProfile(bool2int(check))
 }
 
 // Returns whether or not the user's system profile information is sent when checking for updates.
 func SendsSystemProfile() bool {
-	return C.sendsSystemProfile() != 0
+	return C.sparkle_sendsSystemProfile() != 0
 }
 
 // Sets the decryption password used for extracting updates shipped as Apple Disk Images (dmg)
 func SetDecryptionPassword(url string) {
 	u := C.CString(url)
 	defer C.free(unsafe.Pointer(u))
-	C.setDecryptionPassword(u)
+	C.sparkle_setDecryptionPassword(u)
 }
 
 // Returns the decryption password used for extracting updates shipped as Apple Disk Images (dmg)
 func DecryptionPassword() string {
-	return C.GoString(C.decryptionPassword())
+	return C.GoString(C.sparkle_decryptionPassword())
 }
 
 // Returns the date of last update check.
 func LastUpdateCheckDate() time.Time {
-	s, n := math.Modf(float64(C.lastUpdateCheckDate()))
+	s, n := math.Modf(float64(C.sparkle_lastUpdateCheckDate()))
 	return time.Unix(int64(s), int64(float64(time.Second)*n))
 }
 
@@ -219,10 +219,10 @@ func LastUpdateCheckDate() time.Time {
 // This call does not change the date of the next check,
 // but only the internal NSTimer.
 func ResetUpdateCycle() {
-	C.resetUpdateCycle()
+	C.sparkle_resetUpdateCycle()
 }
 
 // Returns whether or not an update is in progress.
 func UpdateInProgress() bool {
-	return C.updateInProgress() != 0
+	return C.sparkle_updateInProgress() != 0
 }

--- a/sparkle.m
+++ b/sparkle.m
@@ -6,67 +6,67 @@
 
 static SUUpdater *updater = nil;
 
-void initialize() {
+void sparkle_initialize() {
   if (!updater)
     updater = [[SUUpdater sharedUpdater] retain];
 }
 
-void checkForUpdates() { [updater checkForUpdates:updater]; }
+void sparkle_checkForUpdates() { [updater checkForUpdates:updater]; }
 
-void checkForUpdatesInBackground() { [updater checkForUpdatesInBackground]; }
+void sparkle_checkForUpdatesInBackground() { [updater checkForUpdatesInBackground]; }
 
-void setAutomaticallyChecksForUpdates(int check) {
+void sparkle_setAutomaticallyChecksForUpdates(int check) {
   [updater setAutomaticallyChecksForUpdates:check];
 }
 
-int automaticallyChecksForUpdates() {
+int sparkle_automaticallyChecksForUpdates() {
   return [updater automaticallyChecksForUpdates];
 }
 
-void setAutomaticallyDownloadsUpdates(int check) {
+void sparkle_setAutomaticallyDownloadsUpdates(int check) {
   [updater setAutomaticallyDownloadsUpdates:check];
 }
 
-int automaticallyDownloadsUpdates() {
+int sparkle_automaticallyDownloadsUpdates() {
   return [updater automaticallyDownloadsUpdates];
 }
 
-void setUpdateCheckInterval(int interval) {
+void sparkle_setUpdateCheckInterval(int interval) {
   [updater setUpdateCheckInterval:interval];
 }
 
-int updateCheckInterval() { return [updater updateCheckInterval]; }
+int sparkle_updateCheckInterval() { return [updater updateCheckInterval]; }
 
-void checkForUpdateInformation() { [updater checkForUpdateInformation]; }
+void sparkle_checkForUpdateInformation() { [updater checkForUpdateInformation]; }
 
-void setFeedURL(const char *feedURL) {
+void sparkle_setFeedURL(const char *feedURL) {
   [updater setFeedURL:[NSURL URLWithString:@(feedURL)]];
 }
 
-const char *feedURL() {
+const char *sparkle_feedURL() {
   return [[[updater feedURL] absoluteString] UTF8String];
 }
 
-void setUserAgentString(const char *ua) { [updater setUserAgentString:@(ua)]; }
+void sparkle_setUserAgentString(const char *ua) { [updater setUserAgentString:@(ua)]; }
 
-const char *userAgentString() { return [[updater userAgentString] UTF8String]; }
+const char *sparkle_userAgentString() { return [[updater userAgentString] UTF8String]; }
 
-void setSendsSystemProfile(int check) { [updater setSendsSystemProfile:check]; }
+void sparkle_setSendsSystemProfile(int check) { [updater setSendsSystemProfile:check]; }
 
-int sendsSystemProfile() { return [updater sendsSystemProfile]; }
+int sparkle_sendsSystemProfile() { return [updater sendsSystemProfile]; }
 
-void setDecryptionPassword(const char *pw) {
+void sparkle_setDecryptionPassword(const char *pw) {
   [updater setDecryptionPassword:@(pw)];
 }
 
-const char *decryptionPassword() {
+const char *sparkle_decryptionPassword() {
   return [[updater decryptionPassword] UTF8String];
 }
 
-double lastUpdateCheckDate() {
+double sparkle_lastUpdateCheckDate() {
   return [[updater lastUpdateCheckDate] timeIntervalSince1970];
 }
 
-void resetUpdateCycle() { [updater resetUpdateCycle]; }
+void sparkle_resetUpdateCycle() { [updater resetUpdateCycle]; }
 
-int updateInProgress() { return [updater updateInProgress]; }
+int sparkle_updateInProgress() { return [updater updateInProgress]; }


### PR DESCRIPTION
## What this PR does

Prefixes all ObjC code with the package name `sparkle_`

## Why this is important

Unfortunately, the virtual `C` package has a globally shared namespace and ObjC doesn't provide any namespacing capabilities. That leads to functions from `*.m` files clash with other libraries. When most functions are unique, one in particular `initialize` is often used to trigger the global init. ObjC recommends using a class name letter prefix (thus Sparkle uses `SPU`) to help to avoid the clash. 

I faced an issue which looks like this:
```
/opt/homebrew/Cellar/go/1.21.1/libexec/pkg/tool/darwin_arm64/link: running gcc failed: exit status 1
duplicate symbol '_initialize' in:
    /var/folders/55/wfj6z5ps1016qhrhfk2j9fn80000gn/T/go-link-3730058286/000012.o
    /var/folders/55/wfj6z5ps1016qhrhfk2j9fn80000gn/T/go-link-3730058286/000080.o
ld: 1 duplicate symbol for architecture arm64
clang: error: linker command failed with exit code 1 (use -v to see invocation)
```

I still don't know what is the other provider of this function, as we use a plenty of other dependencies which could potentially include a cgo code.

Changing the `initialize` to `sparkle_initialize` solved the issue, however, since this is a purely internal thing and has no impact on the library API, I thought that it might be useful to have all the functions being namespaced to avoid future conflicts and allow better debug (stack traces and complains of the compiler/linker now include `sparkle` more often in errors if something goes wrong).

Please let me know if there is a better prefix, or other solution to the issue (I could imagine there could be a class with some unique name that will be the proxy to all of the methods from sparkle and thus have only the class name "polluting" the global namespace, however, I can't call myself very proficient with ObjC)

A bit more info on the topic:
https://stackoverflow.com/questions/178434/what-is-the-best-way-to-solve-an-objective-c-namespace-collision
