### PR TITLE
fix: update to use SPUStandardUpdaterController from sparkle v2

### DIFF
--- a/delegate.go
+++ b/delegate.go
@@ -1,0 +1,22 @@
+//go:build darwin
+// +build darwin
+
+package sparkle
+
+import "C"
+
+var feedURL = func() string {
+	return ""
+}
+
+// CGOSetFeedURL is a bridge for a Sparkle, fetching the url from a Go function
+// since the Sparkle framework uses a delegate to provide an URL as a feedURLStringForUpdater function result
+// to a SPUUpdater, we need to provide a way to call a feedURL function from an Objective-C function
+//
+//export CGOFeedURL
+func CGOFeedURL() *C.char {
+	if url := feedURL(); url != "" {
+		return C.CString(url)
+	}
+	return nil
+}

--- a/example/main.go
+++ b/example/main.go
@@ -4,8 +4,9 @@ import (
 	"log"
 	"net/http"
 
-	"github.com/abemedia/go-sparkle"
 	webview "github.com/webview/webview_go"
+
+	"github.com/abemedia/go-sparkle"
 )
 
 func main() {
@@ -13,14 +14,25 @@ func main() {
 	// In a real application this would come from a remote source.
 	go func() {
 		log.Fatal(http.ListenAndServe(":3001", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			log.Println("Serving appcast feed", r.URL)
 			w.Header().Set("Content-Type", "application/xml")
 			_, _ = w.Write([]byte(appcastFeed))
 		})))
 	}()
 
+	// It's encouraged to set the url in your Info.plist file and consider channels,
+	// but you can also set them programmatically.
+	sparkle.SetFeedURL("http://localhost:3001/appcast.xml")
+
 	// This is not actually needed and is just designed to manually trigger updates.
 	// Importing github.com/abemedia/go-sparkle is enough to make your app check for updates on startup.
 	sparkle.CheckForUpdates()
+
+	log.Println("Updates check", sparkle.FeedURL(), "by", sparkle.UserAgentString())
+
+	// You can also set the decryption password for DMG programmatically
+	sparkle.SetDecryptionPassword("password")
+	log.Printf("DMG decryption pwd set to <%s>", sparkle.DecryptionPassword())
 
 	w := webview.New(false)
 	defer w.Destroy()

--- a/sparkle.go
+++ b/sparkle.go
@@ -153,22 +153,18 @@ func CheckForUpdateInformation() {
 	C.sparkle_checkForUpdateInformation()
 }
 
-// Sets the URL of the appcast used to download update information.
-//
-// Setting this property will persist in the host bundle's user defaults.
-// If you don't want persistence, you may want to consider instead implementing
-// SUUpdaterDelegate::feedURLStringForUpdater: or SUUpdaterDelegate::feedParametersForUpdater:sendingSystemProfile:
+// Sets the URL of the appcast used to download update information using the SparkleUpdaterDelegate.
 //
 // This property must be called on the main thread.
 func SetFeedURL(url string) {
-	u := C.CString(url)
-	defer C.free(unsafe.Pointer(u))
-	C.sparkle_setFeedURL(u)
+	feedURL = func() string {
+		return url
+	}
 }
 
 // Returns the URL of the appcast used to download update information.
 func FeedURL() string {
-	return C.GoString(C.sparkle_feedURL())
+	return feedURL()
 }
 
 // Sets the user agent used when checking for updates.
@@ -196,8 +192,8 @@ func SendsSystemProfile() bool {
 }
 
 // Sets the decryption password used for extracting updates shipped as Apple Disk Images (dmg)
-func SetDecryptionPassword(url string) {
-	u := C.CString(url)
+func SetDecryptionPassword(pw string) {
+	u := C.CString(pw)
 	defer C.free(unsafe.Pointer(u))
 	C.sparkle_setDecryptionPassword(u)
 }

--- a/sparkle.m
+++ b/sparkle.m
@@ -1,82 +1,106 @@
 #define BUILDING_SPARKLE_SOURCES_EXTERNALLY
 
 #import <Foundation/Foundation.h>
-#import <Headers/SUUpdater.h>
+#import <Headers/SPUUpdater.h>
+#import <Headers/SPUStandardUpdaterController.h>
+#import <Headers/SPUUpdaterDelegate.h>
 #import <objc/runtime.h> // Required for class_addMethod()
+#import "_cgo_export.h"
 
-static SUUpdater *updater = nil;
+@interface SparkleUpdaterDelegate : NSObject <SPUUpdaterDelegate>
 
-void sparkle_initialize() {
-  if (!updater)
-    updater = [[SUUpdater sharedUpdater] retain];
+@property (nonatomic, strong) NSString *decryptionPassword;
+
+@end
+
+static SparkleUpdaterDelegate *delegate = nil;
+static SPUStandardUpdaterController *updateController = nil;
+
+@implementation SparkleUpdaterDelegate
+
+- (NSString *)feedURLStringForUpdater:(SPUUpdater *)updater {
+    char* url = CGOFeedURL();
+    if (url != NULL) {
+        NSString *u = @(url);
+        free(url);
+        return u;
+    }
+    return nil;
 }
 
-void sparkle_checkForUpdates() { [updater checkForUpdates:updater]; }
+- (NSString *)decryptionPasswordForUpdater:(SPUUpdater *)updater {
+    return self.decryptionPassword;
+}
+
+@end
+
+void sparkle_initialize() {
+  if (!updateController) {
+    delegate = [[SparkleUpdaterDelegate alloc] init];
+    updateController = [[SPUStandardUpdaterController alloc]    initWithStartingUpdater:true
+                                                                        updaterDelegate:delegate
+                                                                     userDriverDelegate:nil];
+  }
+}
+
+void sparkle_checkForUpdates() { [updateController checkForUpdates:nil]; }
 
 void sparkle_checkForUpdatesInBackground() {
-  [updater checkForUpdatesInBackground];
+  [updateController.updater checkForUpdatesInBackground];
 }
 
 void sparkle_setAutomaticallyChecksForUpdates(int check) {
-  [updater setAutomaticallyChecksForUpdates:check];
+  [updateController.updater setAutomaticallyChecksForUpdates:check];
 }
 
 int sparkle_automaticallyChecksForUpdates() {
-  return [updater automaticallyChecksForUpdates];
+  return [updateController.updater automaticallyChecksForUpdates];
 }
 
 void sparkle_setAutomaticallyDownloadsUpdates(int check) {
-  [updater setAutomaticallyDownloadsUpdates:check];
+  [updateController.updater setAutomaticallyDownloadsUpdates:check];
 }
 
 int sparkle_automaticallyDownloadsUpdates() {
-  return [updater automaticallyDownloadsUpdates];
+  return [updateController.updater automaticallyDownloadsUpdates];
 }
 
 void sparkle_setUpdateCheckInterval(int interval) {
-  [updater setUpdateCheckInterval:interval];
+  [updateController.updater setUpdateCheckInterval:interval];
 }
 
-int sparkle_updateCheckInterval() { return [updater updateCheckInterval]; }
+int sparkle_updateCheckInterval() { return [updateController.updater updateCheckInterval]; }
 
 void sparkle_checkForUpdateInformation() {
-  [updater checkForUpdateInformation];
-}
-
-void sparkle_setFeedURL(const char *feedURL) {
-  [updater setFeedURL:[NSURL URLWithString:@(feedURL)]];
-}
-
-const char *sparkle_feedURL() {
-  return [[[updater feedURL] absoluteString] UTF8String];
+  [updateController.updater checkForUpdateInformation];
 }
 
 void sparkle_setUserAgentString(const char *ua) {
-  [updater setUserAgentString:@(ua)];
+  [updateController.updater setUserAgentString:@(ua)];
 }
 
 const char *sparkle_userAgentString() {
-  return [[updater userAgentString] UTF8String];
+  return [[updateController.updater userAgentString] UTF8String];
 }
 
 void sparkle_setSendsSystemProfile(int check) {
-  [updater setSendsSystemProfile:check];
+  [updateController.updater setSendsSystemProfile:check];
 }
 
-int sparkle_sendsSystemProfile() { return [updater sendsSystemProfile]; }
+int sparkle_sendsSystemProfile() { return [updateController.updater sendsSystemProfile]; }
 
 void sparkle_setDecryptionPassword(const char *pw) {
-  [updater setDecryptionPassword:@(pw)];
+  delegate.decryptionPassword = @(pw);
 }
 
 const char *sparkle_decryptionPassword() {
-  return [[updater decryptionPassword] UTF8String];
+  return [delegate.decryptionPassword UTF8String];
 }
 
 double sparkle_lastUpdateCheckDate() {
-  return [[updater lastUpdateCheckDate] timeIntervalSince1970];
+  return [[updateController.updater lastUpdateCheckDate] timeIntervalSince1970];
 }
 
-void sparkle_resetUpdateCycle() { [updater resetUpdateCycle]; }
+void sparkle_resetUpdateCycle() { [updateController.updater resetUpdateCycle]; }
 
-int sparkle_updateInProgress() { return [updater updateInProgress]; }
+int sparkle_updateInProgress() { return [updateController.updater sessionInProgress]; }

--- a/sparkle.m
+++ b/sparkle.m
@@ -41,6 +41,23 @@ void sparkle_initialize() {
         [[SPUStandardUpdaterController alloc] initWithStartingUpdater:true
                                                       updaterDelegate:delegate
                                                    userDriverDelegate:nil];
+    /*
+    Clears any feed URL from the host bundle’s user defaults that was set via
+    -setFeedURL:
+
+    You should call this method if you have used -setFeedURL: in the past and
+    want to stop using that API. Otherwise for compatibility Sparkle will prefer
+    to use the feed URL that was set in the user defaults over the one that was
+    specified in the host bundle’s Info.plist, which is often undesirable
+    (except for testing purposes).
+
+    If a feed URL is found stored in the host bundle’s user defaults (from
+    calling -setFeedURL:) before it gets cleared, then that previously set URL
+    is returned from this method.
+
+    For dynamic URL setting we use now delegate method feedURLStringForUpdater:
+    */
+    [updateController.updater clearFeedURLFromUserDefaults];
   }
 }
 

--- a/sparkle.m
+++ b/sparkle.m
@@ -1,15 +1,15 @@
 #define BUILDING_SPARKLE_SOURCES_EXTERNALLY
 
+#import "_cgo_export.h"
 #import <Foundation/Foundation.h>
-#import <Headers/SPUUpdater.h>
 #import <Headers/SPUStandardUpdaterController.h>
+#import <Headers/SPUUpdater.h>
 #import <Headers/SPUUpdaterDelegate.h>
 #import <objc/runtime.h> // Required for class_addMethod()
-#import "_cgo_export.h"
 
 @interface SparkleUpdaterDelegate : NSObject <SPUUpdaterDelegate>
 
-@property (nonatomic, strong) NSString *decryptionPassword;
+@property(nonatomic, strong) NSString *decryptionPassword;
 
 @end
 
@@ -19,17 +19,17 @@ static SPUStandardUpdaterController *updateController = nil;
 @implementation SparkleUpdaterDelegate
 
 - (NSString *)feedURLStringForUpdater:(SPUUpdater *)updater {
-    char* url = CGOFeedURL();
-    if (url != NULL) {
-        NSString *u = @(url);
-        free(url);
-        return u;
-    }
-    return nil;
+  char *url = CGOFeedURL();
+  if (url != NULL) {
+    NSString *u = @(url);
+    free(url);
+    return u;
+  }
+  return nil;
 }
 
 - (NSString *)decryptionPasswordForUpdater:(SPUUpdater *)updater {
-    return self.decryptionPassword;
+  return self.decryptionPassword;
 }
 
 @end
@@ -37,9 +37,10 @@ static SPUStandardUpdaterController *updateController = nil;
 void sparkle_initialize() {
   if (!updateController) {
     delegate = [[SparkleUpdaterDelegate alloc] init];
-    updateController = [[SPUStandardUpdaterController alloc]    initWithStartingUpdater:true
-                                                                        updaterDelegate:delegate
-                                                                     userDriverDelegate:nil];
+    updateController =
+        [[SPUStandardUpdaterController alloc] initWithStartingUpdater:true
+                                                      updaterDelegate:delegate
+                                                   userDriverDelegate:nil];
   }
 }
 
@@ -69,7 +70,9 @@ void sparkle_setUpdateCheckInterval(int interval) {
   [updateController.updater setUpdateCheckInterval:interval];
 }
 
-int sparkle_updateCheckInterval() { return [updateController.updater updateCheckInterval]; }
+int sparkle_updateCheckInterval() {
+  return [updateController.updater updateCheckInterval];
+}
 
 void sparkle_checkForUpdateInformation() {
   [updateController.updater checkForUpdateInformation];
@@ -87,7 +90,9 @@ void sparkle_setSendsSystemProfile(int check) {
   [updateController.updater setSendsSystemProfile:check];
 }
 
-int sparkle_sendsSystemProfile() { return [updateController.updater sendsSystemProfile]; }
+int sparkle_sendsSystemProfile() {
+  return [updateController.updater sendsSystemProfile];
+}
 
 void sparkle_setDecryptionPassword(const char *pw) {
   delegate.decryptionPassword = @(pw);
@@ -103,4 +108,6 @@ double sparkle_lastUpdateCheckDate() {
 
 void sparkle_resetUpdateCycle() { [updateController.updater resetUpdateCycle]; }
 
-int sparkle_updateInProgress() { return [updateController.updater sessionInProgress]; }
+int sparkle_updateInProgress() {
+  return [updateController.updater sessionInProgress];
+}


### PR DESCRIPTION
## What this PR is doing

Fixes #11 by adopting the recommended `SPUStandardUpdaterController` which creates the default UI and necessary delegates.

Feed URL and decryption password settings migrated to `SPUUpdaterDelegate` as methods `feedURLStringForUpdater` and `decryptionPasswordForUpdater`, so to eliminate warnings, I had to implement those.

`feedURLStringForUpdater` calls go function to provide results, which could add some extensibility, however, I haven't changed the library API just yet to expose this way of setting the feed URL.

This PR should be backwards-compatible, but I was forced to export `CGOFeedURL` to use it in the ObjC code. Any suggestions on the naming will be appreciated to indicate, that this is an internal function and implementation detail.

I also slightly tampered with the example to make sure the affected methods did not cause any crashes and still worked fine.

I also had to add a [clearFeedURLFromUserDefaults](https://github.com/abemedia/go-sparkle/pull/24/commits/ab24ad5f4a62222ce232837893876d85d7231dee) call, during my tests with the previous `setFeedURL` version it persisted the URL and didn't get back to the one from `Info.plist`. With this call that was fixed. So I suspect it's a necessary migration step

## Why this PR is important

Having those deprecation warnings is annoying, so I thought It would be nice to finally migrate to a modern second version of the Sparkle API and get familiar with the binding in case I would need more methods exposed in the future