### PR TITLE
feat: Sparkle channels via SPUUpdaterDelegate::allowedChannelsForUpdater

### DIFF
--- a/delegate.go
+++ b/delegate.go
@@ -1,0 +1,22 @@
+//go:build darwin
+// +build darwin
+
+package sparkle
+
+import "C"
+
+var feedURL = func() string {
+	return ""
+}
+
+// CGOSetFeedURL is a bridge for a Sparkle, fetching the url from a Go function
+// since the Sparkle framework uses a delegate to provide an URL as a feedURLStringForUpdater function result
+// to a SPUUpdater, we need to provide a way to call a feedURL function from an Objective-C function
+//
+//export CGOFeedURL
+func CGOFeedURL() *C.char {
+	if url := feedURL(); url != "" {
+		return C.CString(url)
+	}
+	return nil
+}

--- a/example/main.go
+++ b/example/main.go
@@ -4,8 +4,9 @@ import (
 	"log"
 	"net/http"
 
-	"github.com/abemedia/go-sparkle"
 	webview "github.com/webview/webview_go"
+
+	"github.com/abemedia/go-sparkle"
 )
 
 func main() {
@@ -13,14 +14,25 @@ func main() {
 	// In a real application this would come from a remote source.
 	go func() {
 		log.Fatal(http.ListenAndServe(":3001", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			log.Println("Serving appcast feed", r.URL)
 			w.Header().Set("Content-Type", "application/xml")
 			_, _ = w.Write([]byte(appcastFeed))
 		})))
 	}()
 
+	// It's encouraged to set the url in your Info.plist file and consider channels,
+	// but you can also set them programmatically.
+	sparkle.SetFeedURL("http://localhost:3001/appcast.xml")
+
 	// This is not actually needed and is just designed to manually trigger updates.
 	// Importing github.com/abemedia/go-sparkle is enough to make your app check for updates on startup.
 	sparkle.CheckForUpdates()
+
+	log.Println("Updates check", sparkle.FeedURL(), "by", sparkle.UserAgentString())
+
+	// You can also set the decryption password for DMG programmatically
+	sparkle.SetDecryptionPassword("password")
+	log.Printf("DMG decryption pwd set to <%s>", sparkle.DecryptionPassword())
 
 	w := webview.New(false)
 	defer w.Destroy()

--- a/example/main.go
+++ b/example/main.go
@@ -24,6 +24,11 @@ func main() {
 	// but you can also set them programmatically.
 	sparkle.SetFeedURL("http://localhost:3001/appcast.xml")
 
+	// You can set also alternative channels as an addition to the default one.
+	// More info: https://sparkle-project.org/documentation/publishing/#channels
+	sparkle.SetAllowedChannelsForUpdater("beta", "rc")
+	//sparkle.SetAllowedChannelsForUpdater() // call with no args to reset to default behavior
+
 	// This is not actually needed and is just designed to manually trigger updates.
 	// Importing github.com/abemedia/go-sparkle is enough to make your app check for updates on startup.
 	sparkle.CheckForUpdates()
@@ -55,6 +60,14 @@ const appcastFeed = `<?xml version="1.0" encoding="utf-8"?>
 			<description>This is an update.</description>
 			<pubDate>Mon, 28 Jan 2013 14:30:00 +0500</pubDate>
 			<enclosure url="http://example.com/my_app_v2.zip" sparkle:edSignature="7cLALFUHSwvEJWSkV8aMreoBe4fhRa4FncC5NoThKxwThL6FDR7hTiPJh1fo2uagnPogisnQsgFgq6mGkt2RBw==" length="1623481" type="application/octet-stream" />
+		</item>
+		<item>
+			<title>Version 2.0.1 (Beta 1)</title>
+			<sparkle:version>2.0.1-beta</sparkle:version>
+ 			<sparkle:channel>beta</sparkle:channel>
+			<description>This is a beta update which could be explicitly allowed.</description>
+			<pubDate>Mon, 28 Jan 2013 14:30:00 +0500</pubDate>
+			<enclosure url="http://example.com/my_app_v2.0.1beta.zip" sparkle:edSignature="7cLALFUHSwvEJWSkV8aMreoBe4fhRa4FncC5NoThKxwThL6FDR7hTiPJh1fo2uagnPogisnQsgFgq6mGkt2RBw==" length="1623481" type="application/octet-stream" />
 		</item>
 	</channel>
 </rss>`

--- a/sparkle.go
+++ b/sparkle.go
@@ -153,22 +153,18 @@ func CheckForUpdateInformation() {
 	C.sparkle_checkForUpdateInformation()
 }
 
-// Sets the URL of the appcast used to download update information.
-//
-// Setting this property will persist in the host bundle's user defaults.
-// If you don't want persistence, you may want to consider instead implementing
-// SUUpdaterDelegate::feedURLStringForUpdater: or SUUpdaterDelegate::feedParametersForUpdater:sendingSystemProfile:
+// Sets the URL of the appcast used to download update information using the SparkleUpdaterDelegate.
 //
 // This property must be called on the main thread.
 func SetFeedURL(url string) {
-	u := C.CString(url)
-	defer C.free(unsafe.Pointer(u))
-	C.sparkle_setFeedURL(u)
+	feedURL = func() string {
+		return url
+	}
 }
 
 // Returns the URL of the appcast used to download update information.
 func FeedURL() string {
-	return C.GoString(C.sparkle_feedURL())
+	return feedURL()
 }
 
 // Sets the user agent used when checking for updates.
@@ -196,8 +192,8 @@ func SendsSystemProfile() bool {
 }
 
 // Sets the decryption password used for extracting updates shipped as Apple Disk Images (dmg)
-func SetDecryptionPassword(url string) {
-	u := C.CString(url)
+func SetDecryptionPassword(pw string) {
+	u := C.CString(pw)
 	defer C.free(unsafe.Pointer(u))
 	C.sparkle_setDecryptionPassword(u)
 }

--- a/sparkle.go
+++ b/sparkle.go
@@ -42,6 +42,8 @@ int sparkle_sendsSystemProfile();
 void sparkle_setDecryptionPassword(const char*);
 const char* sparkle_decryptionPassword();
 
+void sparkle_setAllowedChannelsForUpdater(const char **channels, int length);
+
 double sparkle_lastUpdateCheckDate();
 
 void sparkle_resetUpdateCycle();
@@ -201,6 +203,29 @@ func SetDecryptionPassword(pw string) {
 // Returns the decryption password used for extracting updates shipped as Apple Disk Images (dmg)
 func DecryptionPassword() string {
 	return C.GoString(C.sparkle_decryptionPassword())
+}
+
+// SetAllowedChannelsForUpdater sets Sparkle channels the updater is allowed to find new updates from.
+// An empty set is the default behavior, which means the updater will only look for updates in the default channel
+//
+// Read more at https://sparkle-project.org/documentation/publishing/#channels
+func SetAllowedChannelsForUpdater(channels ...string) {
+	if len(channels) == 0 {
+		C.sparkle_setAllowedChannelsForUpdater(nil, 0)
+		return
+	}
+
+	mapped := make([]*C.char, len(channels))
+	for i, c := range channels {
+		mapped[i] = C.CString(c)
+	}
+	arrayPtr := (**C.char)(unsafe.Pointer(&mapped[0]))
+
+	C.sparkle_setAllowedChannelsForUpdater(arrayPtr, C.int(len(channels)))
+
+	for i := range channels {
+		C.free(unsafe.Pointer(mapped[i]))
+	}
 }
 
 // Returns the date of last update check.

--- a/sparkle.m
+++ b/sparkle.m
@@ -1,82 +1,106 @@
 #define BUILDING_SPARKLE_SOURCES_EXTERNALLY
 
 #import <Foundation/Foundation.h>
-#import <Headers/SUUpdater.h>
+#import <Headers/SPUUpdater.h>
+#import <Headers/SPUStandardUpdaterController.h>
+#import <Headers/SPUUpdaterDelegate.h>
 #import <objc/runtime.h> // Required for class_addMethod()
+#import "_cgo_export.h"
 
-static SUUpdater *updater = nil;
+@interface SparkleUpdaterDelegate : NSObject <SPUUpdaterDelegate>
 
-void sparkle_initialize() {
-  if (!updater)
-    updater = [[SUUpdater sharedUpdater] retain];
+@property (nonatomic, strong) NSString *decryptionPassword;
+
+@end
+
+static SparkleUpdaterDelegate *delegate = nil;
+static SPUStandardUpdaterController *updateController = nil;
+
+@implementation SparkleUpdaterDelegate
+
+- (NSString *)feedURLStringForUpdater:(SPUUpdater *)updater {
+    char* url = CGOFeedURL();
+    if (url != NULL) {
+        NSString *u = @(url);
+        free(url);
+        return u;
+    }
+    return nil;
 }
 
-void sparkle_checkForUpdates() { [updater checkForUpdates:updater]; }
+- (NSString *)decryptionPasswordForUpdater:(SPUUpdater *)updater {
+    return self.decryptionPassword;
+}
+
+@end
+
+void sparkle_initialize() {
+  if (!updateController) {
+    delegate = [[SparkleUpdaterDelegate alloc] init];
+    updateController = [[SPUStandardUpdaterController alloc]    initWithStartingUpdater:true
+                                                                        updaterDelegate:delegate
+                                                                     userDriverDelegate:nil];
+  }
+}
+
+void sparkle_checkForUpdates() { [updateController checkForUpdates:nil]; }
 
 void sparkle_checkForUpdatesInBackground() {
-  [updater checkForUpdatesInBackground];
+  [updateController.updater checkForUpdatesInBackground];
 }
 
 void sparkle_setAutomaticallyChecksForUpdates(int check) {
-  [updater setAutomaticallyChecksForUpdates:check];
+  [updateController.updater setAutomaticallyChecksForUpdates:check];
 }
 
 int sparkle_automaticallyChecksForUpdates() {
-  return [updater automaticallyChecksForUpdates];
+  return [updateController.updater automaticallyChecksForUpdates];
 }
 
 void sparkle_setAutomaticallyDownloadsUpdates(int check) {
-  [updater setAutomaticallyDownloadsUpdates:check];
+  [updateController.updater setAutomaticallyDownloadsUpdates:check];
 }
 
 int sparkle_automaticallyDownloadsUpdates() {
-  return [updater automaticallyDownloadsUpdates];
+  return [updateController.updater automaticallyDownloadsUpdates];
 }
 
 void sparkle_setUpdateCheckInterval(int interval) {
-  [updater setUpdateCheckInterval:interval];
+  [updateController.updater setUpdateCheckInterval:interval];
 }
 
-int sparkle_updateCheckInterval() { return [updater updateCheckInterval]; }
+int sparkle_updateCheckInterval() { return [updateController.updater updateCheckInterval]; }
 
 void sparkle_checkForUpdateInformation() {
-  [updater checkForUpdateInformation];
-}
-
-void sparkle_setFeedURL(const char *feedURL) {
-  [updater setFeedURL:[NSURL URLWithString:@(feedURL)]];
-}
-
-const char *sparkle_feedURL() {
-  return [[[updater feedURL] absoluteString] UTF8String];
+  [updateController.updater checkForUpdateInformation];
 }
 
 void sparkle_setUserAgentString(const char *ua) {
-  [updater setUserAgentString:@(ua)];
+  [updateController.updater setUserAgentString:@(ua)];
 }
 
 const char *sparkle_userAgentString() {
-  return [[updater userAgentString] UTF8String];
+  return [[updateController.updater userAgentString] UTF8String];
 }
 
 void sparkle_setSendsSystemProfile(int check) {
-  [updater setSendsSystemProfile:check];
+  [updateController.updater setSendsSystemProfile:check];
 }
 
-int sparkle_sendsSystemProfile() { return [updater sendsSystemProfile]; }
+int sparkle_sendsSystemProfile() { return [updateController.updater sendsSystemProfile]; }
 
 void sparkle_setDecryptionPassword(const char *pw) {
-  [updater setDecryptionPassword:@(pw)];
+  delegate.decryptionPassword = @(pw);
 }
 
 const char *sparkle_decryptionPassword() {
-  return [[updater decryptionPassword] UTF8String];
+  return [delegate.decryptionPassword UTF8String];
 }
 
 double sparkle_lastUpdateCheckDate() {
-  return [[updater lastUpdateCheckDate] timeIntervalSince1970];
+  return [[updateController.updater lastUpdateCheckDate] timeIntervalSince1970];
 }
 
-void sparkle_resetUpdateCycle() { [updater resetUpdateCycle]; }
+void sparkle_resetUpdateCycle() { [updateController.updater resetUpdateCycle]; }
 
-int sparkle_updateInProgress() { return [updater updateInProgress]; }
+int sparkle_updateInProgress() { return [updateController.updater sessionInProgress]; }

--- a/sparkle.m
+++ b/sparkle.m
@@ -41,6 +41,23 @@ void sparkle_initialize() {
         [[SPUStandardUpdaterController alloc] initWithStartingUpdater:true
                                                       updaterDelegate:delegate
                                                    userDriverDelegate:nil];
+    /*
+    Clears any feed URL from the host bundle’s user defaults that was set via
+    -setFeedURL:
+
+    You should call this method if you have used -setFeedURL: in the past and
+    want to stop using that API. Otherwise for compatibility Sparkle will prefer
+    to use the feed URL that was set in the user defaults over the one that was
+    specified in the host bundle’s Info.plist, which is often undesirable
+    (except for testing purposes).
+
+    If a feed URL is found stored in the host bundle’s user defaults (from
+    calling -setFeedURL:) before it gets cleared, then that previously set URL
+    is returned from this method.
+
+    For dynamic URL setting we use now delegate method feedURLStringForUpdater:
+    */
+    [updateController.updater clearFeedURLFromUserDefaults];
   }
 }
 

--- a/sparkle.m
+++ b/sparkle.m
@@ -11,6 +11,8 @@
 
 @property(nonatomic, strong) NSString *decryptionPassword;
 
+@property(nonatomic, strong) NSSet<NSString *> *allowedChannelsForUpdater;
+
 @end
 
 static SparkleUpdaterDelegate *delegate = nil;
@@ -30,6 +32,10 @@ static SPUStandardUpdaterController *updateController = nil;
 
 - (NSString *)decryptionPasswordForUpdater:(SPUUpdater *)updater {
   return self.decryptionPassword;
+}
+
+- (NSSet<NSString *> *)allowedChannelsForUpdater:(SPUUpdater *)updater {
+  return self.allowedChannelsForUpdater;
 }
 
 @end
@@ -117,6 +123,15 @@ void sparkle_setDecryptionPassword(const char *pw) {
 
 const char *sparkle_decryptionPassword() {
   return [delegate.decryptionPassword UTF8String];
+}
+
+void sparkle_setAllowedChannelsForUpdater(const char **channels, int length) {
+  NSMutableArray *array = [NSMutableArray arrayWithCapacity:length];
+  for (int i = 0; i < length; i++) {
+    [array addObject:[NSString stringWithUTF8String:channels[i]]];
+  }
+  NSSet *set = [NSSet setWithArray:array];
+  delegate.allowedChannelsForUpdater = set;
 }
 
 double sparkle_lastUpdateCheckDate() {

--- a/sparkle.m
+++ b/sparkle.m
@@ -1,15 +1,15 @@
 #define BUILDING_SPARKLE_SOURCES_EXTERNALLY
 
+#import "_cgo_export.h"
 #import <Foundation/Foundation.h>
-#import <Headers/SPUUpdater.h>
 #import <Headers/SPUStandardUpdaterController.h>
+#import <Headers/SPUUpdater.h>
 #import <Headers/SPUUpdaterDelegate.h>
 #import <objc/runtime.h> // Required for class_addMethod()
-#import "_cgo_export.h"
 
 @interface SparkleUpdaterDelegate : NSObject <SPUUpdaterDelegate>
 
-@property (nonatomic, strong) NSString *decryptionPassword;
+@property(nonatomic, strong) NSString *decryptionPassword;
 
 @end
 
@@ -19,17 +19,17 @@ static SPUStandardUpdaterController *updateController = nil;
 @implementation SparkleUpdaterDelegate
 
 - (NSString *)feedURLStringForUpdater:(SPUUpdater *)updater {
-    char* url = CGOFeedURL();
-    if (url != NULL) {
-        NSString *u = @(url);
-        free(url);
-        return u;
-    }
-    return nil;
+  char *url = CGOFeedURL();
+  if (url != NULL) {
+    NSString *u = @(url);
+    free(url);
+    return u;
+  }
+  return nil;
 }
 
 - (NSString *)decryptionPasswordForUpdater:(SPUUpdater *)updater {
-    return self.decryptionPassword;
+  return self.decryptionPassword;
 }
 
 @end
@@ -37,9 +37,10 @@ static SPUStandardUpdaterController *updateController = nil;
 void sparkle_initialize() {
   if (!updateController) {
     delegate = [[SparkleUpdaterDelegate alloc] init];
-    updateController = [[SPUStandardUpdaterController alloc]    initWithStartingUpdater:true
-                                                                        updaterDelegate:delegate
-                                                                     userDriverDelegate:nil];
+    updateController =
+        [[SPUStandardUpdaterController alloc] initWithStartingUpdater:true
+                                                      updaterDelegate:delegate
+                                                   userDriverDelegate:nil];
   }
 }
 
@@ -69,7 +70,9 @@ void sparkle_setUpdateCheckInterval(int interval) {
   [updateController.updater setUpdateCheckInterval:interval];
 }
 
-int sparkle_updateCheckInterval() { return [updateController.updater updateCheckInterval]; }
+int sparkle_updateCheckInterval() {
+  return [updateController.updater updateCheckInterval];
+}
 
 void sparkle_checkForUpdateInformation() {
   [updateController.updater checkForUpdateInformation];
@@ -87,7 +90,9 @@ void sparkle_setSendsSystemProfile(int check) {
   [updateController.updater setSendsSystemProfile:check];
 }
 
-int sparkle_sendsSystemProfile() { return [updateController.updater sendsSystemProfile]; }
+int sparkle_sendsSystemProfile() {
+  return [updateController.updater sendsSystemProfile];
+}
 
 void sparkle_setDecryptionPassword(const char *pw) {
   delegate.decryptionPassword = @(pw);
@@ -103,4 +108,6 @@ double sparkle_lastUpdateCheckDate() {
 
 void sparkle_resetUpdateCycle() { [updateController.updater resetUpdateCycle]; }
 
-int sparkle_updateInProgress() { return [updateController.updater sessionInProgress]; }
+int sparkle_updateInProgress() {
+  return [updateController.updater sessionInProgress];
+}


### PR DESCRIPTION
## What this PR does:

- implements `SPUUpdaterDelegate::allowedChannelsForUpdater` adding a new method into the public API of the binding: `SetAllowedChannelsForUpdater(...string)`

## Why it could be important:

This is a recommended way to deal with updates which could co-exist with the main line of updates
https://sparkle-project.org/documentation/publishing/#channels

This also simplifies enabling those channels without forcing an alternative appcast URL which could involve some complexity to maintain

This PR is based on #24, so it might be wise to start with that one first